### PR TITLE
Fix polling client memory leak

### DIFF
--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -20,7 +20,7 @@ mod schema;
 use db::{insert_new_record, list as db_list, Db};
 use models::{FileRecord, NewFileRecord};
 
-use notification::{ActiveClients, Client};
+use notification::ActiveClients;
 
 type Result<T, E = Debug<diesel::result::Error>> = std::result::Result<T, E>;
 
@@ -42,7 +42,7 @@ async fn commit(
             let r = NewFileRecord::from_payload_and_user_id(commit_payload, user.id);
             let id: i32 = db.run(move |conn| insert_new_record(conn, r)).await?;
 
-            clients.lock().unwrap().notify(uuid);
+            clients.lock().unwrap().notify(&uuid);
 
             Ok(Json(response::CommitResultStatus::Success(id)))
         }
@@ -75,27 +75,20 @@ async fn poll(
     seconds: u64,
     shutdown: Shutdown,
 ) -> Result<()> {
-    let notification = {
-        let mut data = clients.lock().unwrap();
+    let seconds = notification::clamp_poll_seconds(seconds);
 
-        let client = Client::new(uuid);
-
-        match data.clients.get(&client) {
-            Some(c) => c.notification.clone(),
-            None => {
-                let notification = client.notification.clone();
-                data.clients.insert(client);
-                notification
-            }
-        }
-    };
+    let notification = clients.lock().unwrap().register(&uuid);
 
     let timeout = tokio::time::timeout(Duration::from_secs(seconds), notification.notified());
 
-    tokio::select! {
+    let result = tokio::select! {
         _ = shutdown => Ok(()),
         _ = timeout => Ok(()),
-    }
+    };
+
+    clients.lock().unwrap().remove(&uuid);
+
+    result
 }
 
 pub fn stage() -> AdHoc {

--- a/server/src/metadata/notification.rs
+++ b/server/src/metadata/notification.rs
@@ -1,57 +1,90 @@
-use std::collections::HashSet;
-use std::hash::{Hash, Hasher};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_notify::Notify;
 
-pub(crate) struct Client {
-    uuid: String,
-    pub(crate) notification: Arc<Notify>,
-}
-
-impl Client {
-    pub(crate) fn new(uuid: String) -> Self {
-        Client {
-            uuid,
-            notification: Arc::new(Notify::new()),
-        }
-    }
-}
-impl PartialEq for Client {
-    fn eq(&self, other: &Self) -> bool {
-        self.uuid == other.uuid
-    }
-}
-
-impl Eq for Client {}
-
-impl Hash for Client {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.uuid.hash(state);
-    }
-}
+const MAX_POLL_SECONDS: u64 = 120;
 
 pub(crate) struct ActiveClients {
-    pub(crate) clients: HashSet<Client>,
+    clients: HashMap<String, Arc<Notify>>,
 }
 
 pub(crate) fn init() -> Mutex<ActiveClients> {
     Mutex::new(ActiveClients {
-        clients: HashSet::new(),
+        clients: HashMap::new(),
     })
 }
 
 impl ActiveClients {
-    pub(crate) fn notify(&self, uuid: String) {
-        let notifications: Vec<Arc<Notify>> = self
-            .clients
-            .iter()
-            .filter(|client| client.uuid != uuid)
-            .map(|client| Arc::clone(&client.notification))
-            .collect();
+    pub(crate) fn register(&mut self, uuid: &str) -> Arc<Notify> {
+        self.clients
+            .entry(uuid.to_string())
+            .or_insert_with(|| Arc::new(Notify::new()))
+            .clone()
+    }
 
-        for notification in notifications {
-            notification.notify();
+    pub(crate) fn remove(&mut self, uuid: &str) {
+        self.clients.remove(uuid);
+    }
+
+    pub(crate) fn notify(&self, uuid: &str) {
+        for (client_uuid, notification) in &self.clients {
+            if client_uuid != uuid {
+                notification.notify();
+            }
         }
+    }
+}
+
+pub(crate) fn clamp_poll_seconds(seconds: u64) -> u64 {
+    seconds.min(MAX_POLL_SECONDS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_returns_notification() {
+        let mutex = init();
+        let mut clients = mutex.lock().unwrap();
+        let notify = clients.register("abc");
+        assert!(Arc::strong_count(&notify) == 2); // one in map, one returned
+    }
+
+    #[test]
+    fn register_same_uuid_returns_same_notify() {
+        let mutex = init();
+        let mut clients = mutex.lock().unwrap();
+        let n1 = clients.register("abc");
+        let n2 = clients.register("abc");
+        assert!(Arc::ptr_eq(&n1, &n2));
+    }
+
+    #[test]
+    fn remove_cleans_up_client() {
+        let mutex = init();
+        let mut clients = mutex.lock().unwrap();
+        clients.register("abc");
+        assert_eq!(clients.clients.len(), 1);
+        clients.remove("abc");
+        assert_eq!(clients.clients.len(), 0);
+    }
+
+    #[test]
+    fn notify_skips_sender() {
+        let mutex = init();
+        let mut clients = mutex.lock().unwrap();
+        let _n1 = clients.register("sender");
+        let _n2 = clients.register("receiver");
+        // Should not panic; sender is excluded
+        clients.notify("sender");
+    }
+
+    #[test]
+    fn clamp_poll_seconds_caps_value() {
+        assert_eq!(clamp_poll_seconds(200), MAX_POLL_SECONDS);
+        assert_eq!(clamp_poll_seconds(60), 60);
+        assert_eq!(clamp_poll_seconds(0), 0);
     }
 }


### PR DESCRIPTION
## Summary

- Polling clients were never removed from `ActiveClients` after their request completed, causing unbounded memory growth on long-running servers
- Replaced `HashSet<Client>` with `HashMap<String, Arc<Notify>>`, eliminating the `Client` struct and its `Hash`/`Eq` boilerplate
- Poll endpoint now calls `remove()` after the async wait completes (whether by timeout, notification, or shutdown)
- Added `clamp_poll_seconds()` to cap the client-provided timeout at 120 seconds, preventing abusively long-held connections
- Added unit tests for register, dedup, cleanup, notify filtering, and timeout clamping

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (8 tests including 5 new ones)
- [x] `cargo build` on client crate passes (no API changes on the wire)
- [ ] Manual test with sync-agent polling against local server