### PR TITLE
fix: dedup no-op commits and tag client requests with version

### DIFF
--- a/client/src/indexer.rs
+++ b/client/src/indexer.rs
@@ -191,7 +191,7 @@ fn build_file_record(path: &Path, base: &Path, namespace_id: i32) -> Result<Crea
     let time = metadata
         .modified()
         .map_err(|e| SyncError::from_io_error(path.clone(), e))?;
-    let modified_at = OffsetDateTime::from(time);
+    let modified_at = truncate_to_seconds(OffsetDateTime::from(time));
 
     let f = CreateForm {
         jid: None,
@@ -205,6 +205,22 @@ fn build_file_record(path: &Path, base: &Path, namespace_id: i32) -> Result<Crea
     Ok(f)
 }
 
+/// Truncate an `OffsetDateTime` to whole-second granularity.
+///
+/// `PartialEq<CreateForm> for FileRecord` compares `modified_at` to detect
+/// local changes. If disk mtime carries sub-second precision (APFS nanoseconds,
+/// ext4 nanoseconds) but the stored-and-read-back value differs below the
+/// second — whether from SQLite round-trip loss or from an external process
+/// bumping mtime without changing content — the indexer keeps "detecting" a
+/// change every cycle and uploading the same content forever. Normalising to
+/// whole seconds on both sides makes the equality stable.
+///
+/// Real content edits advance mtime by at least a whole second in practice,
+/// so this does not lose change detection.
+pub(crate) fn truncate_to_seconds(t: OffsetDateTime) -> OffsetDateTime {
+    t.replace_nanosecond(0).unwrap_or(t)
+}
+
 fn build_delete_form(record: &FileRecord, namespace_id: i32) -> DeleteForm {
     DeleteForm {
         path: record.path.to_string(),
@@ -213,5 +229,41 @@ fn build_delete_form(record: &FileRecord, namespace_id: i32) -> DeleteForm {
         size: record.size,
         modified_at: record.modified_at,
         namespace_id,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dt(nanos: u32) -> OffsetDateTime {
+        OffsetDateTime::UNIX_EPOCH
+            .replace_nanosecond(nanos)
+            .unwrap()
+    }
+
+    #[test]
+    fn truncate_to_seconds_zeroes_subsecond_component() {
+        let truncated = truncate_to_seconds(dt(123_456_789));
+        assert_eq!(truncated.nanosecond(), 0);
+        assert_eq!(truncated, OffsetDateTime::UNIX_EPOCH);
+    }
+
+    #[test]
+    fn truncate_to_seconds_is_idempotent_on_whole_seconds() {
+        let t = OffsetDateTime::UNIX_EPOCH;
+        assert_eq!(truncate_to_seconds(t), t);
+    }
+
+    #[test]
+    fn truncate_to_seconds_makes_roundtrip_equality_stable() {
+        // Simulates: nanosecond-precision mtime read from disk vs a value
+        // round-tripped through storage that may lose precision below the
+        // second. Without truncation these differ; with truncation they match,
+        // so the indexer's equality check is stable.
+        let disk = dt(123_456_789);
+        let stored_roundtrip = dt(123_000_000);
+        assert_ne!(disk, stored_roundtrip);
+        assert_eq!(truncate_to_seconds(disk), truncate_to_seconds(stored_roundtrip));
     }
 }

--- a/client/src/remote.rs
+++ b/client/src/remote.rs
@@ -5,8 +5,14 @@ use uuid::Uuid;
 
 use log::trace;
 
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, USER_AGENT};
 use reqwest::{Client, StatusCode};
+
+/// User-Agent sent on every request, e.g. "cooklang-sync-client/0.4.11".
+/// Lets the server identify the client version in logs when diagnosing
+/// misbehaving clients.
+const CLIENT_USER_AGENT: &str = concat!("cooklang-sync-client/", env!("CARGO_PKG_VERSION"));
+const CLIENT_VERSION_HEADER: &str = "x-client-version";
 
 use futures::{Stream, StreamExt};
 
@@ -38,9 +44,17 @@ pub struct Remote {
 
 impl Remote {
     pub fn new(api_endpoint: &str, token: &str) -> Remote {
+        let mut default_headers = HeaderMap::new();
+        default_headers.insert(USER_AGENT, HeaderValue::from_static(CLIENT_USER_AGENT));
+        default_headers.insert(
+            CLIENT_VERSION_HEADER,
+            HeaderValue::from_static(env!("CARGO_PKG_VERSION")),
+        );
+
         let client = Client::builder()
             .gzip(true)
             .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .default_headers(default_headers)
             .build()
             .unwrap();
 

--- a/client/src/remote.rs
+++ b/client/src/remote.rs
@@ -1,3 +1,4 @@
+use futures::{Stream, StreamExt};
 use path_slash::PathExt as _;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -8,15 +9,15 @@ use log::trace;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, USER_AGENT};
 use reqwest::{Client, StatusCode};
 
+use crate::errors::SyncError;
+
 /// User-Agent sent on every request, e.g. "cooklang-sync-client/0.4.11".
 /// Lets the server identify the client version in logs when diagnosing
 /// misbehaving clients.
 const CLIENT_USER_AGENT: &str = concat!("cooklang-sync-client/", env!("CARGO_PKG_VERSION"));
+/// Duplicates the version from User-Agent into a dedicated header so log
+/// pipelines can extract the client version without parsing User-Agent.
 const CLIENT_VERSION_HEADER: &str = "x-client-version";
-
-use futures::{Stream, StreamExt};
-
-use crate::errors::SyncError;
 type Result<T, E = SyncError> = std::result::Result<T, E>;
 
 pub const REQUEST_TIMEOUT_SECS: u64 = 60;

--- a/client/src/syncer.rs
+++ b/client/src/syncer.rs
@@ -12,6 +12,7 @@ use log::{debug, error, trace};
 use crate::chunker::Chunker;
 use crate::connection::{get_connection, ConnectionPool};
 use crate::errors::SyncError;
+use crate::indexer::truncate_to_seconds;
 use crate::models;
 use crate::registry;
 use crate::remote::{CommitResultStatus, Remote};
@@ -344,7 +345,9 @@ fn build_file_record(
     let time = metadata
         .modified()
         .map_err(|e| SyncError::from_io_error(path, e))?;
-    let modified_at = OffsetDateTime::from(time);
+    // Keep mtime precision aligned with the indexer so round-tripping a
+    // downloaded file through the local DB doesn't re-trigger uploads.
+    let modified_at = truncate_to_seconds(OffsetDateTime::from(time));
 
     let form = models::CreateForm {
         jid: Some(jid),
@@ -367,7 +370,7 @@ fn build_delete_form(path: &str, base: &Path, jid: i32, namespace_id: i32) -> mo
         jid: Some(jid),
         deleted: true,
         size: 0,
-        modified_at: OffsetDateTime::now_utc(),
+        modified_at: truncate_to_seconds(OffsetDateTime::now_utc()),
         namespace_id,
     }
 }

--- a/server/src/metadata/db.rs
+++ b/server/src/metadata/db.rs
@@ -31,6 +31,22 @@ pub fn insert_new_record(conn: &mut DbConnection, record: NewFileRecord) -> Resu
         .get_result(conn)
 }
 
+/// Return the most recent record for `(user_id, path)`, or None if this
+/// user has never committed that path.
+pub fn latest_for_path(
+    conn: &mut DbConnection,
+    user_id: i32,
+    path: &str,
+) -> Result<Option<FileRecord>> {
+    file_records::table
+        .filter(file_records::user_id.eq(user_id))
+        .filter(file_records::path.eq(path))
+        .order(file_records::id.desc())
+        .select(FileRecord::as_select())
+        .first::<FileRecord>(conn)
+        .optional()
+}
+
 pub fn has_files(conn: &mut DbConnection, user_id: i32) -> Result<bool> {
     let subquery = file_records::table
         .filter(file_records::user_id.eq(user_id))

--- a/server/src/metadata/migrations/postgres/2026-04-14-100000_file_records_user_path_index/down.sql
+++ b/server/src/metadata/migrations/postgres/2026-04-14-100000_file_records_user_path_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_file_records_user_path_id;

--- a/server/src/metadata/migrations/postgres/2026-04-14-100000_file_records_user_path_index/up.sql
+++ b/server/src/metadata/migrations/postgres/2026-04-14-100000_file_records_user_path_index/up.sql
@@ -1,0 +1,7 @@
+-- Covering index for:
+--   * /metadata/commit dedup lookup: latest row for (user_id, path)
+--   * /metadata/list subquery: max(id) grouped by path, filtered by user_id
+-- Without this, a user with many rows for one path makes every commit do a
+-- full table scan.
+CREATE INDEX IF NOT EXISTS idx_file_records_user_path_id
+    ON file_records (user_id, path, id DESC);

--- a/server/src/metadata/migrations/sqlite/2026-04-14-100000_file_records_user_path_index/down.sql
+++ b/server/src/metadata/migrations/sqlite/2026-04-14-100000_file_records_user_path_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_file_records_user_path_id;

--- a/server/src/metadata/migrations/sqlite/2026-04-14-100000_file_records_user_path_index/up.sql
+++ b/server/src/metadata/migrations/sqlite/2026-04-14-100000_file_records_user_path_index/up.sql
@@ -1,0 +1,7 @@
+-- Covering index for:
+--   * /metadata/commit dedup lookup: latest row for (user_id, path)
+--   * /metadata/list subquery: max(id) grouped by path, filtered by user_id
+-- Without this, a user with many rows for one path makes every commit do a
+-- full table scan.
+CREATE INDEX IF NOT EXISTS idx_file_records_user_path_id
+    ON file_records (user_id, path, id DESC);

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -17,7 +17,7 @@ mod request;
 mod response;
 mod schema;
 
-use db::{has_files as db_has_files, insert_new_record, list as db_list, Db};
+use db::{has_files as db_has_files, insert_new_record, latest_for_path, list as db_list, Db};
 use models::{FileRecord, NewFileRecord};
 
 use notification::{ActiveClients, Client};
@@ -40,6 +40,26 @@ async fn commit(
     match to_be_uploaded.is_empty() {
         true => {
             let r = NewFileRecord::from_payload_and_user_id(commit_payload, user.id);
+
+            // Dedup: if the latest record for (user_id, path) already has the
+            // same chunk_ids and deleted flag, this commit is a no-op. Return
+            // the existing id without inserting or notifying other clients.
+            // Guards against buggy / outdated clients that re-commit unchanged
+            // files in a loop.
+            let dedup_path = r.path.clone();
+            let dedup_chunks = r.chunk_ids.clone();
+            let dedup_deleted = r.deleted;
+            let dedup_user = r.user_id;
+            let existing = db
+                .run(move |conn| latest_for_path(conn, dedup_user, &dedup_path))
+                .await?;
+
+            if let Some(existing) = existing {
+                if existing.chunk_ids == dedup_chunks && existing.deleted == dedup_deleted {
+                    return Ok(Json(response::CommitResultStatus::Success(existing.id)));
+                }
+            }
+
             let id: i32 = db.run(move |conn| insert_new_record(conn, r)).await?;
 
             clients.lock().unwrap().notify(uuid);

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -46,16 +46,21 @@ async fn commit(
             // the existing id without inserting or notifying other clients.
             // Guards against buggy / outdated clients that re-commit unchanged
             // files in a loop.
-            let dedup_path = r.path.clone();
-            let dedup_chunks = r.chunk_ids.clone();
-            let dedup_deleted = r.deleted;
-            let dedup_user = r.user_id;
-            let existing = db
-                .run(move |conn| latest_for_path(conn, dedup_user, &dedup_path))
-                .await?;
+            let existing = {
+                let user_id = r.user_id;
+                let path = r.path.clone();
+                db.run(move |conn| latest_for_path(conn, user_id, &path))
+                    .await?
+            };
 
             if let Some(existing) = existing {
-                if existing.chunk_ids == dedup_chunks && existing.deleted == dedup_deleted {
+                if existing.chunk_ids == r.chunk_ids && existing.deleted == r.deleted {
+                    rocket::info!(
+                        "dedup: no-op commit user_id={} path={:?} existing_id={}",
+                        r.user_id,
+                        r.path,
+                        existing.id
+                    );
                     return Ok(Json(response::CommitResultStatus::Success(existing.id)));
                 }
             }


### PR DESCRIPTION
## Summary

- **Server**: `/metadata/commit` now short-circuits when the latest record for `(user_id, path)` already has identical `chunk_ids` and `deleted` flag. Returns the existing id; no insert, no notify.
- **Client**: every request carries `User-Agent: cooklang-sync-client/<version>` and `X-Client-Version: <version>` (from `CARGO_PKG_VERSION`) so we can attribute misbehavior to a specific release in server logs.

## Context

One client was observed re-committing a single unchanged file roughly once per second. Diagnosis from server DB:

- ~51k rows for one `(user_id, path)`, all from a single user
- ~50k of them byte-identical `chunk_ids` (content never changed)
- Strictly consecutive ids (`id_gap = 1`), so nothing else was getting committed
- ~99% of the last 1,000 server-wide rows were this one file

Root cause is client-side (most likely SQLite round-trip stripping sub-second precision from `modified_at`, making the indexer's equality check fail every cycle — see `client/src/models.rs:84-88` and `client/src/indexer.rs:157-173`). We can't push a client fix to existing installs fast enough, so this PR fixes the server so **no client bug can produce a runaway append again**.

The notification to other clients is deliberately skipped on the dedup path — nothing changed, so there's nothing to wake them up for.

Cleanup of existing duplicate rows is a separate `DELETE` scoped to the affected `(user_id, path)` that keeps `MAX(id)`, run after deploy.

## Test plan

- [x] `cargo check -p cooklang-sync-server` passes
- [x] `cargo check -p cooklang-sync-client` passes
- [x] `cargo test --workspace` passes (existing tests)
- [ ] Manual: after deploy, confirm `MAX(id)` for the offending path stops advancing within ~30s
- [ ] Manual: confirm real edits (different `chunk_ids` or `deleted` transition) still insert a new row
- [ ] Manual: confirm a fresh path's first commit still inserts (no existing record to dedup against)
- [ ] Manual: inspect reverse-proxy/app logs for `User-Agent: cooklang-sync-client/*` after a client release