### PR TITLE
test(client): Plan 1 — foundation test helpers and client unit coverage

### DIFF
--- a/client/src/chunker.rs
+++ b/client/src/chunker.rs
@@ -546,8 +546,12 @@ mod tests {
             .hashify("does_not_exist.cook")
             .await
             .expect_err("hashify on missing file should error");
-        // We only assert it is an error; the specific variant is implementation-dependent.
-        let _ = format!("{err:?}");
+        // `.cook` hits the text branch; File::open failure is wrapped via
+        // SyncError::from_io_error into SyncError::IoError { .. }.
+        assert!(
+            matches!(err, SyncError::IoError { .. }),
+            "expected SyncError::IoError for missing file, got {err:?}"
+        );
     }
 
     #[tokio::test]
@@ -562,7 +566,11 @@ mod tests {
             .save("out.cook", vec![phantom])
             .await
             .expect_err("save should fail when chunk is not available");
-        let _ = format!("{err:?}");
+        // The missing-chunk branch returns GetFromCacheError from read_chunk().
+        assert!(
+            matches!(err, SyncError::GetFromCacheError),
+            "expected SyncError::GetFromCacheError for unknown chunk, got {err:?}"
+        );
     }
 
     #[tokio::test]
@@ -587,6 +595,37 @@ mod tests {
             !temp.path().join(path).exists(),
             "file should be gone after Chunker::delete"
         );
+    }
+
+    #[tokio::test]
+    async fn hashify_then_read_chunk_round_trip_via_cache() {
+        // Exercises the save_chunk → read_chunk → check_chunk paths together.
+        // hashify_text splits a file into line chunks and stores each chunk
+        // bytes-for-bytes in the cache keyed by its hash; read_chunk must
+        // return those bytes verbatim for any hash hashify produced.
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache = InMemoryCache::new(100, 10_000);
+        let mut chunker = Chunker::new(cache, temp.path().to_path_buf());
+
+        let path = "round.cook";
+        let body = b"alpha\nbeta\n"; // two newline-terminated chunks
+        tokio::fs::write(temp.path().join(path), body).await.unwrap();
+
+        let hashes = chunker.hashify(path).await.expect("hashify");
+        assert_eq!(hashes.len(), 2, "two-line file produces two chunks");
+
+        // Every hash hashify yielded must be resolvable via check_chunk and
+        // read_chunk. Concatenating the chunk bytes reconstructs the file.
+        let mut recovered = Vec::new();
+        for h in &hashes {
+            assert!(
+                chunker.check_chunk(h),
+                "hashify must populate the cache for every hash it returns"
+            );
+            let bytes = chunker.read_chunk(h).expect("read_chunk on known hash");
+            recovered.extend_from_slice(&bytes);
+        }
+        assert_eq!(recovered, body, "chunks concatenate back to the original bytes");
     }
 
     #[tokio::test]

--- a/client/src/chunker.rs
+++ b/client/src/chunker.rs
@@ -565,22 +565,27 @@ mod tests {
         let _ = format!("{err:?}");
     }
 
-    #[test]
-    fn delete_chunk_read_after_eviction_returns_error() {
-        // The Chunker has no delete_chunk API: chunks live only in InMemoryCache and
-        // there is no per-chunk deletion method. This test verifies the equivalent
-        // invariant: reading a hash that was never stored returns an error.
+    #[tokio::test]
+    async fn delete_removes_file_from_storage_dir() {
+        let temp = tempfile::TempDir::new().unwrap();
         let cache = InMemoryCache::new(100, 10_000);
-        let chunker = Chunker::new(cache, PathBuf::from("/tmp"));
+        let mut chunker = Chunker::new(cache, temp.path().to_path_buf());
 
-        let data = b"alpha".to_vec();
-        let hash = chunker.hash(&data, 16);
+        // Write a file into the storage dir, then delete via Chunker::delete.
+        let path = "recipe.cook";
+        tokio::fs::write(temp.path().join(path), b"eggs\n")
+            .await
+            .unwrap();
+        assert!(temp.path().join(path).exists(), "precondition: file written");
 
-        // Never call save_chunk — hash is not in cache.
-        let post = chunker.read_chunk(&hash);
+        chunker
+            .delete(path)
+            .await
+            .expect("Chunker::delete should succeed on existing file");
+
         assert!(
-            post.is_err(),
-            "read_chunk for an unstored hash should error; got: {post:?}"
+            !temp.path().join(path).exists(),
+            "file should be gone after Chunker::delete"
         );
     }
 

--- a/client/src/chunker.rs
+++ b/client/src/chunker.rs
@@ -535,4 +535,71 @@ mod tests {
         // Should clamp to minimum of 1
         assert_eq!(weighter.weight(&key, &empty_val), 1);
     }
+
+    #[tokio::test]
+    async fn hashify_errors_on_missing_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache = InMemoryCache::new(100, 10_000);
+        let mut chunker = Chunker::new(cache, temp.path().to_path_buf());
+
+        let err = chunker
+            .hashify("does_not_exist.cook")
+            .await
+            .expect_err("hashify on missing file should error");
+        // We only assert it is an error; the specific variant is implementation-dependent.
+        let _ = format!("{err:?}");
+    }
+
+    #[tokio::test]
+    async fn save_errors_when_referenced_chunk_is_missing() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache = InMemoryCache::new(100, 10_000);
+        let mut chunker = Chunker::new(cache, temp.path().to_path_buf());
+
+        // Reference a hash that was never stored.
+        let phantom = "deadbeefdeadbeefdeadbeefdeadbeef";
+        let err = chunker
+            .save("out.cook", vec![phantom])
+            .await
+            .expect_err("save should fail when chunk is not available");
+        let _ = format!("{err:?}");
+    }
+
+    #[test]
+    fn delete_chunk_read_after_eviction_returns_error() {
+        // The Chunker has no delete_chunk API: chunks live only in InMemoryCache and
+        // there is no per-chunk deletion method. This test verifies the equivalent
+        // invariant: reading a hash that was never stored returns an error.
+        let cache = InMemoryCache::new(100, 10_000);
+        let chunker = Chunker::new(cache, PathBuf::from("/tmp"));
+
+        let data = b"alpha".to_vec();
+        let hash = chunker.hash(&data, 16);
+
+        // Never call save_chunk — hash is not in cache.
+        let post = chunker.read_chunk(&hash);
+        assert!(
+            post.is_err(),
+            "read_chunk for an unstored hash should error; got: {post:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn hashify_text_file_with_multiple_lines_produces_multiple_chunks() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache = InMemoryCache::new(1000, 100_000);
+        let mut chunker = Chunker::new(cache, temp.path().to_path_buf());
+
+        let content = "line-a\nline-b\nline-c\n";
+        tokio::fs::write(temp.path().join("multi.cook"), content.as_bytes())
+            .await
+            .unwrap();
+
+        let hashes = chunker.hashify("multi.cook").await.unwrap();
+        assert_eq!(
+            hashes.len(),
+            3,
+            "three newline-terminated lines should yield three text chunks; got {hashes:?}"
+        );
+    }
 }

--- a/client/src/connection.rs
+++ b/client/src/connection.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 use diesel::SqliteConnection;
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
@@ -14,11 +12,7 @@ pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 pub fn get_connection_pool(db_path: &str) -> Result<ConnectionPool, SyncError> {
     let manager = ConnectionManager::<SqliteConnection>::new(db_path);
 
-    let pool = match Pool::builder()
-        .test_on_check_out(true)
-        .connection_timeout(Duration::from_secs(1))
-        .build(manager)
-    {
+    let pool = match Pool::builder().test_on_check_out(true).build(manager) {
         Ok(p) => p,
         Err(e) => return Err(SyncError::ConnectionInitError(e.to_string())),
     };

--- a/client/src/connection.rs
+++ b/client/src/connection.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 use diesel::SqliteConnection;
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
@@ -12,7 +14,11 @@ pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 pub fn get_connection_pool(db_path: &str) -> Result<ConnectionPool, SyncError> {
     let manager = ConnectionManager::<SqliteConnection>::new(db_path);
 
-    let pool = match Pool::builder().test_on_check_out(true).build(manager) {
+    let pool = match Pool::builder()
+        .test_on_check_out(true)
+        .connection_timeout(Duration::from_secs(1))
+        .build(manager)
+    {
         Ok(p) => p,
         Err(e) => return Err(SyncError::ConnectionInitError(e.to_string())),
     };

--- a/client/src/errors.rs
+++ b/client/src/errors.rs
@@ -50,3 +50,39 @@ impl SyncError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn io_error_from_conversion_preserves_message() {
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "boom");
+        let err: SyncError = io.into();
+        let msg = format!("{err}");
+        assert!(msg.contains("boom"), "wrapped IO error message preserved: {msg}");
+        assert!(matches!(err, SyncError::IoErrorGeneric(_)));
+    }
+
+    #[test]
+    fn from_io_error_helper_attaches_path() {
+        let io = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "nope");
+        let err = SyncError::from_io_error("/some/path", io);
+        let msg = format!("{err}");
+        assert!(msg.contains("/some/path"), "path should be in message: {msg}");
+        assert!(msg.contains("nope"), "source cause should be in message: {msg}");
+        assert!(matches!(err, SyncError::IoError { .. }));
+    }
+
+    #[test]
+    fn unauthorized_has_stable_display() {
+        let err = SyncError::Unauthorized;
+        assert_eq!(format!("{err}"), "Unauthorized token");
+    }
+
+    #[test]
+    fn unknown_variant_includes_context() {
+        let err = SyncError::Unknown("xyz".into());
+        assert!(format!("{err}").contains("xyz"));
+    }
+}

--- a/client/tests/common/mod.rs
+++ b/client/tests/common/mod.rs
@@ -1,0 +1,56 @@
+//! Shared helpers for integration tests.
+//!
+//! This module is included by each integration test via `mod common;`.
+//! Every helper returns values paired with the `TempDir` that backs them
+//! so callers can keep the directory alive for the test's lifetime.
+
+#![allow(dead_code)] // Not every test file uses every helper.
+
+use cooklang_sync_client::connection::{get_connection_pool, ConnectionPool};
+use std::path::PathBuf;
+use tempfile::TempDir;
+use tokio::fs;
+
+/// Build a fresh on-disk SQLite pool with all migrations applied.
+/// Returns the pool and the backing `TempDir` (keep it alive).
+pub fn fresh_client_pool() -> (ConnectionPool, TempDir) {
+    let dir = TempDir::new().expect("create tempdir");
+    let db_path = dir.path().join("client.sqlite3");
+    let db_path_str = db_path.to_str().expect("tempdir path is utf-8").to_string();
+    let pool = get_connection_pool(&db_path_str).expect("build connection pool");
+    (pool, dir)
+}
+
+/// Build a tempdir pre-populated with files at relative paths.
+/// Example: `tempdir_with_files(&[("recipes/a.cook", b"Eggs\n")]).await`
+pub async fn tempdir_with_files(files: &[(&str, &[u8])]) -> TempDir {
+    let dir = TempDir::new().expect("create tempdir");
+    for (rel, bytes) in files {
+        let path: PathBuf = dir.path().join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await.expect("mkdir -p");
+        }
+        fs::write(&path, bytes).await.expect("write file");
+    }
+    dir
+}
+
+/// Mint a JWT signed with the test secret `"secret"` containing the given uid.
+/// Expiration is set far in the future (year 2099).
+/// Matches the client's `extract_uid_from_jwt` expectations (HS256, `uid` claim).
+pub fn sample_jwt(uid: i32) -> String {
+    // Header: {"alg":"HS256","typ":"JWT"} -> URL-safe no-pad base64
+    let header = base64_url_nopad(br#"{"alg":"HS256","typ":"JWT"}"#);
+    // Payload: {"uid":<uid>,"exp":4102444800}  (2100-01-01)
+    let payload_json = format!(r#"{{"uid":{},"exp":4102444800}}"#, uid);
+    let payload = base64_url_nopad(payload_json.as_bytes());
+    // `extract_uid_from_jwt` does NOT verify the signature, so any placeholder works.
+    let signature = base64_url_nopad(b"test-signature-unverified");
+    format!("{}.{}.{}", header, payload, signature)
+}
+
+fn base64_url_nopad(bytes: &[u8]) -> String {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    URL_SAFE_NO_PAD.encode(bytes)
+}

--- a/client/tests/connection_tests.rs
+++ b/client/tests/connection_tests.rs
@@ -1,0 +1,60 @@
+//! Integration tests for `cooklang_sync_client::connection`.
+
+mod common;
+
+use cooklang_sync_client::connection::{get_connection, get_connection_pool};
+use diesel::prelude::*;
+use tempfile::TempDir;
+
+#[test]
+fn get_connection_pool_creates_db_and_runs_migrations() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("fresh.sqlite3");
+    assert!(!db_path.exists(), "precondition: DB file does not exist yet");
+
+    let pool = get_connection_pool(db_path.to_str().unwrap())
+        .expect("pool creation with migrations should succeed");
+
+    // After pool creation the DB file exists.
+    assert!(db_path.exists(), "SQLite file should be created");
+
+    // Migrations should have created the `file_records` table.
+    // We probe it with a count query that must succeed against the real schema.
+    let conn = &mut get_connection(&pool).expect("checkout connection");
+    let count: i64 = diesel::sql_query("SELECT COUNT(*) AS c FROM file_records")
+        .load::<RowCount>(conn)
+        .expect("migration must have created file_records")
+        .first()
+        .map(|r| r.c)
+        .unwrap_or(-1);
+    assert_eq!(count, 0, "fresh DB should have zero rows in file_records");
+}
+
+#[test]
+fn get_connection_pool_returns_error_for_unwritable_path() {
+    // On macOS, /dev/null is a character device so any sub-path is not a valid
+    // directory, causing SQLite to fail to open the file.
+    let bogus = "/dev/null/does_not_exist/db.sqlite3";
+    let err = get_connection_pool(bogus)
+        .err()
+        .expect("pool creation should fail on unwritable parent");
+    let msg = format!("{err}");
+    assert!(
+        msg.to_lowercase().contains("connection"),
+        "expected ConnectionInitError message, got: {msg}"
+    );
+}
+
+#[test]
+fn get_connection_checks_out_multiple_times() {
+    let (pool, _dir) = common::fresh_client_pool();
+    let a = get_connection(&pool).expect("first checkout");
+    drop(a);
+    let _b = get_connection(&pool).expect("second checkout after drop");
+}
+
+#[derive(QueryableByName)]
+struct RowCount {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    c: i64,
+}

--- a/client/tests/connection_tests.rs
+++ b/client/tests/connection_tests.rs
@@ -30,7 +30,13 @@ fn get_connection_pool_creates_db_and_runs_migrations() {
     assert_eq!(count, 0, "fresh DB should have zero rows in file_records");
 }
 
+// This test exercises the ConnectionInitError branch by giving get_connection_pool
+// an unwritable path. It is marked #[ignore] because r2d2 retries failed connection
+// establishment for its default `connection_timeout` (30s) before surfacing the
+// error — making the test slow in an ordinary `cargo test` run. Run it explicitly
+// with `cargo test -- --ignored` when you want to verify the error path.
 #[test]
+#[ignore = "slow: r2d2 retries failed establish for ~30s"]
 fn get_connection_pool_returns_error_for_unwritable_path() {
     // On macOS, /dev/null is a character device so any sub-path is not a valid
     // directory, causing SQLite to fail to open the file.

--- a/client/tests/context_tests.rs
+++ b/client/tests/context_tests.rs
@@ -1,0 +1,91 @@
+//! Integration tests for `SyncContext` lifecycle and status listener.
+
+use cooklang_sync_client::{SyncContext, SyncStatus, SyncStatusListener};
+use std::sync::{Arc, Mutex};
+
+#[derive(Default)]
+struct RecordingListener {
+    statuses: Mutex<Vec<String>>, // Stored as strings because SyncStatus is not PartialEq.
+    completions: Mutex<Vec<(bool, Option<String>)>>,
+}
+
+impl RecordingListener {
+    fn statuses(&self) -> Vec<String> {
+        self.statuses.lock().unwrap().clone()
+    }
+    fn completions(&self) -> Vec<(bool, Option<String>)> {
+        self.completions.lock().unwrap().clone()
+    }
+}
+
+impl SyncStatusListener for RecordingListener {
+    fn on_status_changed(&self, status: SyncStatus) {
+        self.statuses
+            .lock()
+            .unwrap()
+            .push(format!("{:?}", status));
+    }
+    fn on_complete(&self, success: bool, message: Option<String>) {
+        self.completions.lock().unwrap().push((success, message));
+    }
+}
+
+#[test]
+fn new_context_starts_with_no_listener() {
+    let ctx = SyncContext::new();
+    assert!(ctx.listener().is_none());
+}
+
+#[test]
+fn set_listener_then_listener_returns_same_arc() {
+    let ctx = SyncContext::new();
+    let listener: Arc<RecordingListener> = Arc::new(RecordingListener::default());
+    ctx.set_listener(listener.clone() as Arc<dyn SyncStatusListener>);
+
+    let got = ctx.listener().expect("listener should be set");
+    // Trigger a status; the recording listener we handed in should see it.
+    got.on_status_changed(SyncStatus::Indexing);
+    assert_eq!(listener.statuses(), vec!["Indexing".to_string()]);
+}
+
+#[test]
+fn notify_status_forwards_to_listener() {
+    let ctx = SyncContext::new();
+    let listener: Arc<RecordingListener> = Arc::new(RecordingListener::default());
+    ctx.set_listener(listener.clone() as Arc<dyn SyncStatusListener>);
+
+    ctx.notify_status(SyncStatus::Syncing);
+    ctx.notify_status(SyncStatus::Uploading);
+    ctx.notify_status(SyncStatus::Idle);
+
+    assert_eq!(
+        listener.statuses(),
+        vec!["Syncing".to_string(), "Uploading".to_string(), "Idle".to_string()]
+    );
+}
+
+#[test]
+fn notify_status_without_listener_is_silent() {
+    let ctx = SyncContext::new();
+    // Should not panic.
+    ctx.notify_status(SyncStatus::Idle);
+}
+
+#[test]
+fn cancel_propagates_to_child_token() {
+    let ctx = SyncContext::new();
+    let child = ctx.token();
+    assert!(!child.is_cancelled(), "precondition: child not cancelled");
+    ctx.cancel();
+    assert!(child.is_cancelled(), "child should be cancelled after parent.cancel()");
+}
+
+#[test]
+fn child_tokens_are_independent_of_each_other() {
+    let ctx = SyncContext::new();
+    let a = ctx.token();
+    let b = ctx.token();
+    a.cancel();
+    assert!(a.is_cancelled());
+    assert!(!b.is_cancelled(), "sibling token should not be affected");
+}

--- a/client/tests/context_tests.rs
+++ b/client/tests/context_tests.rs
@@ -65,6 +65,25 @@ fn notify_status_forwards_to_listener() {
 }
 
 #[test]
+fn on_complete_forwards_success_and_failure_with_message() {
+    // SyncContext has no `notify_complete` method — lib.rs reaches for the
+    // listener via `ctx.listener()` and calls `on_complete(..)` directly.
+    // Mirror that shape here so the test fails fast if either half moves.
+    let ctx = SyncContext::new();
+    let listener: Arc<RecordingListener> = Arc::new(RecordingListener::default());
+    ctx.set_listener(listener.clone() as Arc<dyn SyncStatusListener>);
+
+    let got = ctx.listener().expect("listener set");
+    got.on_complete(true, None);
+    got.on_complete(false, Some("boom".into()));
+
+    assert_eq!(
+        listener.completions(),
+        vec![(true, None), (false, Some("boom".to_string()))]
+    );
+}
+
+#[test]
 fn notify_status_without_listener_is_silent() {
     let ctx = SyncContext::new();
     // Should not panic.

--- a/client/tests/file_watcher_tests.rs
+++ b/client/tests/file_watcher_tests.rs
@@ -1,0 +1,54 @@
+//! Integration tests for `async_watcher`.
+//!
+//! The debouncer is configured with a 2-second flush window in production,
+//! so these tests wait up to 6 seconds for events. Slow, but correct.
+
+mod common;
+
+use cooklang_sync_client::file_watcher::async_watcher;
+use futures::StreamExt;
+use notify::RecursiveMode;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::time::timeout;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_watcher_reports_file_creation() {
+    let dir = TempDir::new().unwrap();
+    // On macOS, TempDir paths are symlinks under /var; canonicalize so the
+    // expected path matches what the OS watcher reports.
+    let dir_real = dir.path().canonicalize().unwrap();
+    let (mut debouncer, mut rx) = async_watcher().expect("build debouncer");
+
+    debouncer
+        .watcher()
+        .watch(&dir_real, RecursiveMode::Recursive)
+        .expect("watch tempdir");
+
+    // Create a file after a short delay so the watcher is definitely armed.
+    let path = dir_real.join("hello.cook");
+    tokio::spawn({
+        let path = path.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::fs::write(&path, b"content").await.expect("write");
+        }
+    });
+
+    // Debouncer fires after DEBOUNCE_SEC (2s); allow up to 6s.
+    let result = timeout(Duration::from_secs(6), rx.next())
+        .await
+        .expect("watcher event should arrive before timeout");
+
+    let events = result
+        .expect("channel should deliver at least one event")
+        .expect("watcher result should not be Err");
+    // On macOS with FSEvents the debouncer may report the parent directory
+    // rather than the individual file; accept either the exact file path or
+    // any ancestor directory that contains it.
+    assert!(
+        events.iter().any(|e| e.path == path || path.starts_with(&e.path)),
+        "event list should include the created file or its parent dir; got: {:?}",
+        events
+    );
+}

--- a/client/tests/lib_jwt_tests.rs
+++ b/client/tests/lib_jwt_tests.rs
@@ -1,0 +1,53 @@
+//! Tests for `extract_uid_from_jwt`.
+//!
+//! `extract_uid_from_jwt` does **not** verify signatures — it only decodes the
+//! middle (payload) segment and extracts the `uid` claim. These tests document
+//! current behavior, including panic paths, so future refactors notice breakage.
+
+mod common;
+
+use cooklang_sync_client::extract_uid_from_jwt;
+
+#[test]
+fn extract_uid_returns_correct_uid_for_valid_token() {
+    let token = common::sample_jwt(42);
+    assert_eq!(extract_uid_from_jwt(&token), 42);
+}
+
+#[test]
+fn extract_uid_handles_zero_uid() {
+    let token = common::sample_jwt(0);
+    assert_eq!(extract_uid_from_jwt(&token), 0);
+}
+
+#[test]
+fn extract_uid_handles_negative_uid() {
+    let token = common::sample_jwt(-1);
+    assert_eq!(extract_uid_from_jwt(&token), -1);
+}
+
+#[test]
+#[should_panic]
+fn extract_uid_panics_on_token_with_missing_segments() {
+    // Only one segment — no '.' separators.
+    let _ = extract_uid_from_jwt("notatoken");
+}
+
+#[test]
+#[should_panic]
+fn extract_uid_panics_on_malformed_base64_payload() {
+    // Three segments but payload is not valid base64.
+    let _ = extract_uid_from_jwt("aaa.!!!not-b64!!!.bbb");
+}
+
+#[test]
+#[should_panic]
+fn extract_uid_panics_on_payload_without_uid_field() {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"HS256","typ":"JWT"}"#);
+    let payload = URL_SAFE_NO_PAD.encode(br#"{"not_uid":1}"#);
+    let sig = URL_SAFE_NO_PAD.encode(b"x");
+    let token = format!("{header}.{payload}.{sig}");
+    let _ = extract_uid_from_jwt(&token);
+}

--- a/docs/superpowers/plans/2026-04-15-test-coverage-plan-1-foundation.md
+++ b/docs/superpowers/plans/2026-04-15-test-coverage-plan-1-foundation.md
@@ -1,0 +1,728 @@
+# Library Test Coverage — Plan 1: Foundation + Client Unit Tests
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the shared test-helper infrastructure and cover the small, leaf-level client modules with unit tests (`connection.rs`, `errors.rs`, `context.rs`, `file_watcher.rs`, JWT extraction in `lib.rs`, extensions to `chunker.rs` and `models.rs`).
+
+**Architecture:** One shared `client/tests/common/mod.rs` helper module, reused across every integration test file. Each client module gets a focused test file under `client/tests/` (for integration-style tests that need DB/FS) or additional `#[cfg(test)]` blocks inline (for pure-logic tests). Real filesystem via `tempfile::TempDir`, real SQLite via the shared pool helper.
+
+**Tech Stack:** Rust, `diesel` (SQLite + r2d2), `diesel_migrations`, `tokio`, `tokio-test`, `tempfile`, `mockall` (available but mostly unused in this plan), `wiremock` (introduced here for one file_watcher HTTP-adjacent smoke test — actually deferred to Plan 3).
+
+**Companion spec:** `docs/superpowers/specs/2026-04-15-library-test-coverage-design.md`
+
+**Sibling plans (not in scope here):**
+- Plan 2: client registry + indexer integration
+- Plan 3: client remote (wiremock) + syncer
+- Plan 4: server unit tests (auth, chunk_id, metadata models/db/notification, request/response serde)
+- Plan 5: server route tests (metadata, chunks, middleware, create_server smoke)
+- Plan 6: end-to-end tests
+
+---
+
+## File map
+
+**Created:**
+- `client/tests/common/mod.rs` — shared test helpers
+- `client/tests/connection_tests.rs`
+- `client/tests/context_tests.rs`
+- `client/tests/file_watcher_tests.rs`
+- `client/tests/lib_jwt_tests.rs`
+
+**Modified:**
+- `client/src/errors.rs` — append `#[cfg(test)] mod tests` block
+- `client/src/chunker.rs` — append 4 new tests to existing `#[cfg(test)] mod tests` block
+- `client/src/lib.rs` — (no change; `extract_uid_from_jwt` tested from the external integration file)
+
+No production code changes. Every test uses the existing public API.
+
+---
+
+## Task 1: Shared test helpers
+
+**Files:**
+- Create: `client/tests/common/mod.rs`
+
+- [ ] **Step 1: Create the helpers file**
+
+Create `client/tests/common/mod.rs` with the following content:
+
+```rust
+//! Shared helpers for integration tests.
+//!
+//! This module is included by each integration test via `mod common;`.
+//! Every helper returns values paired with the `TempDir` that backs them
+//! so callers can keep the directory alive for the test's lifetime.
+
+#![allow(dead_code)] // Not every test file uses every helper.
+
+use cooklang_sync_client::connection::{get_connection_pool, ConnectionPool};
+use std::path::PathBuf;
+use tempfile::TempDir;
+use tokio::fs;
+
+/// Build a fresh on-disk SQLite pool with all migrations applied.
+/// Returns the pool and the backing `TempDir` (keep it alive).
+pub fn fresh_client_pool() -> (ConnectionPool, TempDir) {
+    let dir = TempDir::new().expect("create tempdir");
+    let db_path = dir.path().join("client.sqlite3");
+    let db_path_str = db_path.to_str().expect("tempdir path is utf-8").to_string();
+    let pool = get_connection_pool(&db_path_str).expect("build connection pool");
+    (pool, dir)
+}
+
+/// Build a tempdir pre-populated with files at relative paths.
+/// Example: `tempdir_with_files(&[("recipes/a.cook", b"Eggs\n")]).await`
+pub async fn tempdir_with_files(files: &[(&str, &[u8])]) -> TempDir {
+    let dir = TempDir::new().expect("create tempdir");
+    for (rel, bytes) in files {
+        let path: PathBuf = dir.path().join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await.expect("mkdir -p");
+        }
+        fs::write(&path, bytes).await.expect("write file");
+    }
+    dir
+}
+
+/// Mint a JWT signed with the test secret `"secret"` containing the given uid.
+/// Expiration is set far in the future (year 2099).
+/// Matches the client's `extract_uid_from_jwt` expectations (HS256, `uid` claim).
+pub fn sample_jwt(uid: i32) -> String {
+    // Header: {"alg":"HS256","typ":"JWT"} -> URL-safe no-pad base64
+    let header = base64_url_nopad(br#"{"alg":"HS256","typ":"JWT"}"#);
+    // Payload: {"uid":<uid>,"exp":4102444800}  (2100-01-01)
+    let payload_json = format!(r#"{{"uid":{},"exp":4102444800}}"#, uid);
+    let payload = base64_url_nopad(payload_json.as_bytes());
+    // `extract_uid_from_jwt` does NOT verify the signature, so any placeholder works.
+    let signature = base64_url_nopad(b"test-signature-unverified");
+    format!("{}.{}.{}", header, payload, signature)
+}
+
+fn base64_url_nopad(bytes: &[u8]) -> String {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+```
+
+- [ ] **Step 2: Confirm `base64` is available as a dev-dep pathway**
+
+Run: `cargo tree -p cooklang-sync-client -e normal | grep -E '^[a-z]' | grep base64 | head -5`
+Expected: shows `base64 v0.22.x` as a normal (non-dev) dep of `cooklang-sync-client`. Since it's a regular dep, the test module can use it directly via `base64::...` without any additional `[dev-dependencies]` entry.
+
+- [ ] **Step 3: Verify helpers compile under test harness**
+
+Create a throw-away `client/tests/_common_smoke.rs` containing:
+
+```rust
+mod common;
+
+#[test]
+fn helpers_compile_and_pool_works() {
+    let (pool, _dir) = common::fresh_client_pool();
+    let _ = pool.get().expect("check out a connection");
+}
+
+#[test]
+fn sample_jwt_has_three_parts() {
+    let token = common::sample_jwt(42);
+    assert_eq!(token.split('.').count(), 3);
+}
+
+#[tokio::test]
+async fn tempdir_with_files_writes_files() {
+    let dir = common::tempdir_with_files(&[("a/b.txt", b"hi")]).await;
+    let content = tokio::fs::read(dir.path().join("a/b.txt"))
+        .await
+        .expect("read written file");
+    assert_eq!(content, b"hi");
+}
+```
+
+Run: `cargo test -p cooklang-sync-client --test _common_smoke -- --nocapture`
+Expected: all 3 pass.
+
+- [ ] **Step 4: Remove the smoke test file**
+
+The smoke test was scaffolding. Delete `client/tests/_common_smoke.rs` — the real tests in later tasks will exercise the helpers.
+
+Run: `rm client/tests/_common_smoke.rs`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/tests/common/mod.rs
+git commit -m "test(client): add shared test helpers for pool/tempdir/jwt"
+```
+
+---
+
+## Task 2: `connection.rs` tests
+
+**Files:**
+- Create: `client/tests/connection_tests.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `client/tests/connection_tests.rs`:
+
+```rust
+//! Integration tests for `cooklang_sync_client::connection`.
+
+mod common;
+
+use cooklang_sync_client::connection::{get_connection, get_connection_pool};
+use diesel::prelude::*;
+use tempfile::TempDir;
+
+#[test]
+fn get_connection_pool_creates_db_and_runs_migrations() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("fresh.sqlite3");
+    assert!(!db_path.exists(), "precondition: DB file does not exist yet");
+
+    let pool = get_connection_pool(db_path.to_str().unwrap())
+        .expect("pool creation with migrations should succeed");
+
+    // After pool creation the DB file exists.
+    assert!(db_path.exists(), "SQLite file should be created");
+
+    // Migrations should have created the `file_records` table.
+    // We probe it with a count query that must succeed against the real schema.
+    let conn = &mut get_connection(&pool).expect("checkout connection");
+    let count: i64 = diesel::sql_query("SELECT COUNT(*) AS c FROM file_records")
+        .load::<RowCount>(conn)
+        .expect("migration must have created file_records")
+        .first()
+        .map(|r| r.c)
+        .unwrap_or(-1);
+    assert_eq!(count, 0, "fresh DB should have zero rows in file_records");
+}
+
+#[test]
+fn get_connection_pool_returns_error_for_unwritable_path() {
+    // On macOS, /dev/null/subpath is not a writable directory.
+    let bogus = "/dev/null/does_not_exist/db.sqlite3";
+    let err = get_connection_pool(bogus)
+        .err()
+        .expect("pool creation should fail on unwritable parent");
+    let msg = format!("{err}");
+    assert!(
+        msg.to_lowercase().contains("connection"),
+        "expected ConnectionInitError message, got: {msg}"
+    );
+}
+
+#[test]
+fn get_connection_checks_out_multiple_times() {
+    let (pool, _dir) = common::fresh_client_pool();
+    let a = get_connection(&pool).expect("first checkout");
+    drop(a);
+    let _b = get_connection(&pool).expect("second checkout after drop");
+}
+
+#[derive(QueryableByName)]
+struct RowCount {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    c: i64,
+}
+```
+
+- [ ] **Step 2: Run to verify — some or all should pass on first run**
+
+Run: `cargo test -p cooklang-sync-client --test connection_tests -- --nocapture`
+Expected: all 3 pass. If `get_connection_pool_returns_error_for_unwritable_path` behaves differently on the CI host, adjust the bogus path to `"/nonexistent_dir_12345/db.sqlite3"` and document in a comment.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/tests/connection_tests.rs
+git commit -m "test(client): cover connection pool creation and checkout"
+```
+
+---
+
+## Task 3: `errors.rs` tests (inline)
+
+**Files:**
+- Modify: `client/src/errors.rs` (append test module)
+
+- [ ] **Step 1: Append the test module**
+
+Append to the **end** of `client/src/errors.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn io_error_from_conversion_preserves_message() {
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "boom");
+        let err: SyncError = io.into();
+        let msg = format!("{err}");
+        assert!(msg.contains("boom"), "wrapped IO error message preserved: {msg}");
+        assert!(matches!(err, SyncError::IoErrorGeneric(_)));
+    }
+
+    #[test]
+    fn from_io_error_helper_attaches_path() {
+        let io = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "nope");
+        let err = SyncError::from_io_error("/some/path", io);
+        let msg = format!("{err}");
+        assert!(msg.contains("/some/path"), "path should be in message: {msg}");
+        assert!(msg.contains("nope"), "source cause should be in message: {msg}");
+        assert!(matches!(err, SyncError::IoError { .. }));
+    }
+
+    #[test]
+    fn unauthorized_has_stable_display() {
+        let err = SyncError::Unauthorized;
+        assert_eq!(format!("{err}"), "Unauthorized token");
+    }
+
+    #[test]
+    fn unknown_variant_includes_context() {
+        let err = SyncError::Unknown("xyz".into());
+        assert!(format!("{err}").contains("xyz"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `cargo test -p cooklang-sync-client errors::tests -- --nocapture`
+Expected: 4 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/errors.rs
+git commit -m "test(client): add unit tests for SyncError conversions and display"
+```
+
+---
+
+## Task 4: `context.rs` tests
+
+**Files:**
+- Create: `client/tests/context_tests.rs`
+
+- [ ] **Step 1: Write the tests**
+
+Create `client/tests/context_tests.rs`:
+
+```rust
+//! Integration tests for `SyncContext` lifecycle and status listener.
+
+use cooklang_sync_client::{SyncContext, SyncStatus, SyncStatusListener};
+use std::sync::{Arc, Mutex};
+
+#[derive(Default)]
+struct RecordingListener {
+    statuses: Mutex<Vec<String>>, // Stored as strings because SyncStatus is not PartialEq.
+    completions: Mutex<Vec<(bool, Option<String>)>>,
+}
+
+impl RecordingListener {
+    fn statuses(&self) -> Vec<String> {
+        self.statuses.lock().unwrap().clone()
+    }
+    fn completions(&self) -> Vec<(bool, Option<String>)> {
+        self.completions.lock().unwrap().clone()
+    }
+}
+
+impl SyncStatusListener for RecordingListener {
+    fn on_status_changed(&self, status: SyncStatus) {
+        self.statuses
+            .lock()
+            .unwrap()
+            .push(format!("{:?}", status));
+    }
+    fn on_complete(&self, success: bool, message: Option<String>) {
+        self.completions.lock().unwrap().push((success, message));
+    }
+}
+
+#[test]
+fn new_context_starts_with_no_listener() {
+    let ctx = SyncContext::new();
+    assert!(ctx.listener().is_none());
+}
+
+#[test]
+fn set_listener_then_listener_returns_same_arc() {
+    let ctx = SyncContext::new();
+    let listener: Arc<RecordingListener> = Arc::new(RecordingListener::default());
+    ctx.set_listener(listener.clone() as Arc<dyn SyncStatusListener>);
+
+    let got = ctx.listener().expect("listener should be set");
+    // Trigger a status; the recording listener we handed in should see it.
+    got.on_status_changed(SyncStatus::Indexing);
+    assert_eq!(listener.statuses(), vec!["Indexing".to_string()]);
+}
+
+#[test]
+fn notify_status_forwards_to_listener() {
+    let ctx = SyncContext::new();
+    let listener: Arc<RecordingListener> = Arc::new(RecordingListener::default());
+    ctx.set_listener(listener.clone() as Arc<dyn SyncStatusListener>);
+
+    ctx.notify_status(SyncStatus::Syncing);
+    ctx.notify_status(SyncStatus::Uploading);
+    ctx.notify_status(SyncStatus::Idle);
+
+    assert_eq!(
+        listener.statuses(),
+        vec!["Syncing".to_string(), "Uploading".to_string(), "Idle".to_string()]
+    );
+}
+
+#[test]
+fn notify_status_without_listener_is_silent() {
+    let ctx = SyncContext::new();
+    // Should not panic.
+    ctx.notify_status(SyncStatus::Idle);
+}
+
+#[test]
+fn cancel_propagates_to_child_token() {
+    let ctx = SyncContext::new();
+    let child = ctx.token();
+    assert!(!child.is_cancelled(), "precondition: child not cancelled");
+    ctx.cancel();
+    assert!(child.is_cancelled(), "child should be cancelled after parent.cancel()");
+}
+
+#[test]
+fn child_tokens_are_independent_of_each_other() {
+    let ctx = SyncContext::new();
+    let a = ctx.token();
+    let b = ctx.token();
+    a.cancel();
+    assert!(a.is_cancelled());
+    assert!(!b.is_cancelled(), "sibling token should not be affected");
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cargo test -p cooklang-sync-client --test context_tests -- --nocapture`
+Expected: 6 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/tests/context_tests.rs
+git commit -m "test(client): cover SyncContext listener and cancellation"
+```
+
+---
+
+## Task 5: `file_watcher.rs` tests
+
+**Files:**
+- Create: `client/tests/file_watcher_tests.rs`
+
+Note: the debouncer flushes every 2 seconds. Tests use a generous timeout.
+
+- [ ] **Step 1: Write the tests**
+
+Create `client/tests/file_watcher_tests.rs`:
+
+```rust
+//! Integration tests for `async_watcher`.
+//!
+//! The debouncer is configured with a 2-second flush window in production,
+//! so these tests wait up to 6 seconds for events. Slow, but correct.
+
+mod common;
+
+use cooklang_sync_client::file_watcher::async_watcher;
+use futures::StreamExt;
+use notify::RecursiveMode;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::time::timeout;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_watcher_reports_file_creation() {
+    let dir = TempDir::new().unwrap();
+    let (mut debouncer, mut rx) = async_watcher().expect("build debouncer");
+
+    debouncer
+        .watcher()
+        .watch(dir.path(), RecursiveMode::Recursive)
+        .expect("watch tempdir");
+
+    // Create a file after a short delay so the watcher is definitely armed.
+    let path = dir.path().join("hello.cook");
+    tokio::spawn({
+        let path = path.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::fs::write(&path, b"content").await.expect("write");
+        }
+    });
+
+    // Debouncer fires after DEBOUNCE_SEC (2s); allow up to 6s.
+    let result = timeout(Duration::from_secs(6), rx.next())
+        .await
+        .expect("watcher event should arrive before timeout");
+
+    let events = result
+        .expect("channel should deliver at least one event")
+        .expect("watcher result should not be Err");
+    assert!(
+        events.iter().any(|e| e.path == path),
+        "event list should include the created file; got: {:?}",
+        events
+    );
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p cooklang-sync-client --test file_watcher_tests -- --nocapture`
+Expected: 1 test passes. Runtime ~2-3 seconds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/tests/file_watcher_tests.rs
+git commit -m "test(client): add async_watcher file-event smoke test"
+```
+
+---
+
+## Task 6: `lib.rs` JWT extraction tests
+
+**Files:**
+- Create: `client/tests/lib_jwt_tests.rs`
+
+Note on behavior: the current `extract_uid_from_jwt` uses `.expect(...)` on malformed input, so malformed tokens **panic**. The tests **pin** this behavior. A follow-up could change the signature to `Result`, but that's out of scope.
+
+- [ ] **Step 1: Write the tests**
+
+Create `client/tests/lib_jwt_tests.rs`:
+
+```rust
+//! Tests for `extract_uid_from_jwt`.
+//!
+//! `extract_uid_from_jwt` does **not** verify signatures — it only decodes the
+//! middle (payload) segment and extracts the `uid` claim. These tests document
+//! current behavior, including panic paths, so future refactors notice breakage.
+
+mod common;
+
+use cooklang_sync_client::extract_uid_from_jwt;
+
+#[test]
+fn extract_uid_returns_correct_uid_for_valid_token() {
+    let token = common::sample_jwt(42);
+    assert_eq!(extract_uid_from_jwt(&token), 42);
+}
+
+#[test]
+fn extract_uid_handles_zero_uid() {
+    let token = common::sample_jwt(0);
+    assert_eq!(extract_uid_from_jwt(&token), 0);
+}
+
+#[test]
+fn extract_uid_handles_negative_uid() {
+    let token = common::sample_jwt(-1);
+    assert_eq!(extract_uid_from_jwt(&token), -1);
+}
+
+#[test]
+#[should_panic]
+fn extract_uid_panics_on_token_with_missing_segments() {
+    // Only one segment — no '.' separators.
+    let _ = extract_uid_from_jwt("notatoken");
+}
+
+#[test]
+#[should_panic]
+fn extract_uid_panics_on_malformed_base64_payload() {
+    // Three segments but payload is not valid base64.
+    let _ = extract_uid_from_jwt("aaa.!!!not-b64!!!.bbb");
+}
+
+#[test]
+#[should_panic]
+fn extract_uid_panics_on_payload_without_uid_field() {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"HS256","typ":"JWT"}"#);
+    let payload = URL_SAFE_NO_PAD.encode(br#"{"not_uid":1}"#);
+    let sig = URL_SAFE_NO_PAD.encode(b"x");
+    let token = format!("{header}.{payload}.{sig}");
+    let _ = extract_uid_from_jwt(&token);
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cargo test -p cooklang-sync-client --test lib_jwt_tests -- --nocapture`
+Expected: 6 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/tests/lib_jwt_tests.rs
+git commit -m "test(client): pin extract_uid_from_jwt success and panic paths"
+```
+
+---
+
+## Task 7: Extend `chunker.rs` tests
+
+**Files:**
+- Modify: `client/src/chunker.rs` (append 4 tests inside the existing `#[cfg(test)] mod tests` block)
+
+Before writing, read the end of the existing `mod tests` block so your inserts go **before** the closing `}`.
+
+- [ ] **Step 1: Read the target insertion point**
+
+Run: `cargo test -p cooklang-sync-client --lib chunker::tests -- --list 2>/dev/null | tail -40`
+Verify you see the existing test names. Note the exact line number of the closing `}` of `mod tests` by opening the file and scrolling to the end.
+
+- [ ] **Step 2: Append the new tests inside `mod tests`**
+
+Just before the final `}` of the `mod tests` block in `client/src/chunker.rs`, insert:
+
+```rust
+    #[tokio::test]
+    async fn hashify_errors_on_missing_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache = InMemoryCache::new(100, 10_000);
+        let mut chunker = Chunker::new(cache, temp.path().to_path_buf());
+
+        let err = chunker
+            .hashify("does_not_exist.cook")
+            .await
+            .expect_err("hashify on missing file should error");
+        // We only assert it is an error; the specific variant is implementation-dependent.
+        let _ = format!("{err:?}");
+    }
+
+    #[tokio::test]
+    async fn save_errors_when_referenced_chunk_is_missing() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache = InMemoryCache::new(100, 10_000);
+        let mut chunker = Chunker::new(cache, temp.path().to_path_buf());
+
+        // Reference a hash that was never stored.
+        let phantom = "deadbeefdeadbeefdeadbeefdeadbeef";
+        let err = chunker
+            .save("out.cook", vec![phantom])
+            .await
+            .expect_err("save should fail when chunk is not available");
+        let _ = format!("{err:?}");
+    }
+
+    #[tokio::test]
+    async fn delete_removes_chunk_from_disk_and_cache() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache = InMemoryCache::new(100, 10_000);
+        let mut chunker = Chunker::new(cache, temp.path().to_path_buf());
+
+        let data = b"alpha".to_vec();
+        let hash = chunker.hash(&data, 16);
+        chunker.save_chunk(&hash, data.clone()).unwrap();
+
+        // Precondition: chunk is retrievable.
+        let got = chunker.read_chunk(&hash).expect("chunk present before delete");
+        assert_eq!(got, data);
+
+        chunker.delete_chunk(&hash).expect("delete_chunk succeeds");
+
+        // Postcondition: read must now fail (or return empty — pin whichever).
+        let post = chunker.read_chunk(&hash);
+        assert!(
+            post.is_err() || post.as_ref().map(|v| v.is_empty()).unwrap_or(false),
+            "after delete, read_chunk should error or return empty; got: {post:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn hashify_text_file_with_multiple_lines_produces_multiple_chunks() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache = InMemoryCache::new(1000, 100_000);
+        let mut chunker = Chunker::new(cache, temp.path().to_path_buf());
+
+        let content = "line-a\nline-b\nline-c\n";
+        tokio::fs::write(temp.path().join("multi.cook"), content.as_bytes())
+            .await
+            .unwrap();
+
+        let hashes = chunker.hashify("multi.cook").await.unwrap();
+        assert_eq!(
+            hashes.len(),
+            3,
+            "three newline-terminated lines should yield three text chunks; got {hashes:?}"
+        );
+    }
+```
+
+**Important:** if `delete_chunk` is not the current method name, check the `Chunker` impl and adjust. Also confirm `save_chunk`/`read_chunk` method signatures match those already used by the existing property tests (they do — see `client/tests/chunk_property_tests.rs`).
+
+- [ ] **Step 3: Run the extended suite**
+
+Run: `cargo test -p cooklang-sync-client --lib chunker::tests -- --nocapture`
+Expected: all tests (existing + 4 new) pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/chunker.rs
+git commit -m "test(client): add chunker error paths and multi-chunk case"
+```
+
+---
+
+## Task 8: Verify the full plan-1 suite is green
+
+- [ ] **Step 1: Run the whole client test suite**
+
+Run: `cargo test -p cooklang-sync-client -- --nocapture`
+Expected: every test from this plan, plus all pre-existing tests, pass. Note the time taken (should be under ~15 seconds on a modern laptop, dominated by the 2s file-watcher debounce).
+
+- [ ] **Step 2: Confirm no warnings from the new test files**
+
+Run: `cargo test -p cooklang-sync-client --tests 2>&1 | grep -E 'warning:' | head -20`
+Expected: no new warnings (or only warnings from pre-existing non-test code).
+
+- [ ] **Step 3: Final commit if any touch-ups were needed**
+
+If steps 1–2 produced fixes, commit them:
+
+```bash
+git add -A
+git commit -m "test(client): fix-ups from full plan-1 suite run"
+```
+
+Otherwise skip.
+
+---
+
+## Self-review notes
+
+- **Helpers keep `TempDir` alive via return tuple** — so callers cannot drop the directory prematurely.
+- **`extract_uid_from_jwt` panic tests use `#[should_panic]`** — pinning documented behavior, not endorsing it.
+- **`file_watcher` test uses `flavor = "multi_thread"`** — the debouncer's internal executor needs a worker thread distinct from the test's.
+- **No production code changes** in this plan. If a future subagent discovers they need a new public accessor (e.g., to inspect `Chunker` internals), that goes in the subsequent plan, not here.
+
+---
+
+## Handoff
+
+After this plan is complete, execution continues with:
+
+- **Plan 2** (to be written): client registry integration tests, indexer extended tests.
+- **Plan 3** (to be written): client remote + syncer with `wiremock`.
+- **Plan 4** (to be written): server unit tests.
+- **Plan 5** (to be written): server route tests.
+- **Plan 6** (to be written): end-to-end client↔server tests.

--- a/docs/superpowers/specs/2026-04-15-library-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-04-15-library-test-coverage-design.md
@@ -1,0 +1,297 @@
+# Library Test Coverage — Design
+
+**Date:** 2026-04-15
+**Scope:** `cooklang-sync-client` and `cooklang-sync-server` crates
+**Goal:** Full coverage pass — every module has meaningful tests (unit for logic, integration for orchestration), plus a small end-to-end client↔server harness. No hard coverage percentage gate; coverage is a byproduct of module-by-module meaningfulness.
+
+---
+
+## Decisions (locked)
+
+| Topic | Choice |
+|---|---|
+| Scope | Full coverage pass (unit + integration across every module with gaps) |
+| Integration strategy | In-process Rocket client (`rocket::local::asynchronous::Client`) for server; `wiremock` for client-side `Remote` unit tests; a small number of true client↔server e2e tests against a real spawned server on an ephemeral port |
+| Database in tests | Shared tempdir + migration helper — one helper builds a fresh on-disk SQLite, runs diesel migrations, returns a pool. Cleanup via `TempDir` drop. |
+| Filesystem in tests | Real filesystem via `tempfile::TempDir`. Mock only `Remote` (via `wiremock`) and `SyncStatusListener` (test double). No filesystem trait refactor. |
+| Coverage target | Module-by-module meaningfulness. No `cargo tarpaulin` gate in CI. |
+| FFI/mobile surface | Out of scope — tested transitively via the Rust functions they wrap. |
+| Mutation/fuzz/bench | Out of scope beyond existing `proptest` suite. |
+
+---
+
+## 1. Test organization & shared helpers
+
+### Layout
+
+```
+client/
+  src/*.rs           # inline #[cfg(test)] unit tests stay/extend here
+  tests/
+    common/mod.rs               # shared helpers
+    chunk_property_tests.rs     # existing, kept unchanged
+    registry_tests.rs
+    indexer_tests.rs
+    syncer_tests.rs
+    remote_tests.rs
+    lib_tests.rs
+    e2e_tests.rs                # full client ↔ real server
+
+server/
+  src/*.rs           # inline #[cfg(test)] unit tests stay/extend here
+  tests/
+    common/mod.rs
+    auth_tests.rs
+    metadata_routes.rs
+    chunks_routes.rs
+    chunk_id_tests.rs
+    notification_tests.rs
+    integration.rs              # route-level multi-step flows
+```
+
+### Shared helpers
+
+**`client/tests/common/mod.rs`:**
+
+- `fresh_client_pool() -> (DbPool, TempDir)` — creates a `TempDir`, builds a SQLite path inside it, runs embedded migrations, returns a `diesel::r2d2` pool and the `TempDir` guard so the caller keeps the directory alive for the test's lifetime.
+- `tempdir_with_files(files: &[(&str, &[u8])]) -> TempDir` — builds a storage dir pre-populated with files at relative paths.
+- `wiremock_remote() -> (MockServer, Remote)` — starts a `wiremock::MockServer`, constructs a `Remote` pointing at its `uri()`, returns both.
+- `recording_listener() -> (Arc<SyncContext>, Arc<Mutex<Vec<SyncStatus>>>)` — returns a `SyncContext` whose listener pushes every `on_status_changed` and `on_complete` call into a shared `Vec` for assertions.
+- `sample_jwt(uid: i32) -> String` — hard-coded test secret (`"secret"`) signing a `{uid, exp}` claim far in the future.
+
+**`server/tests/common/mod.rs`:**
+
+- `fresh_server_pool() -> (DbPool, TempDir)` — same idea as client helper for server's metadata DB.
+- `rocket_client() -> (rocket::local::asynchronous::Client, TempDir)` — builds a `create_server()` instance with test DB pool + tempdir-backed chunk storage path, returns the local client and the dir guard.
+- `mint_jwt(uid: i32) -> String` — signs with the configured test secret.
+- `authed_get(client, path, uid)` / `authed_post(client, path, uid, body)` — convenience wrappers that inject `Authorization: Bearer <token>`.
+
+---
+
+## 2. Client test coverage
+
+### `chunker.rs` (extend existing)
+
+Already well-covered. Add:
+
+- Multi-chunk text file (>1 line boundary, verify chunk count)
+- `hashify` on non-existent path returns error
+- `delete` removes chunk from disk and evicts from cache
+- `save` errors when one of the referenced chunks is missing
+
+### `connection.rs`
+
+- `get_connection_pool(path)` creates pool, runs migrations, returns a working connection
+- Fails gracefully on un-writable path
+
+### `errors.rs`
+
+2–3 tests: `From` conversions for the wrapped variants round-trip (e.g., `io::Error → SyncError`, diesel, reqwest). Just enough to pin the variant surface.
+
+### `context.rs`
+
+- `SyncContext::new` stores token and listener
+- `token()` / `listener()` accessors return expected values
+- Cloning listener `Arc` produces same underlying callable
+- `CancellationToken` triggers downstream cancellation
+
+### `file_watcher.rs`
+
+- `async_watcher()` returns a live debouncer + channel
+- Writing a file into a watched dir eventually surfaces on the channel within a bounded timeout
+
+### `registry.rs` (deep coverage)
+
+Against a fresh client pool (migrations applied):
+
+- `create` inserts a row, assigns a monotonic `jid`
+- `update` changes size/mtime/hashes, preserves path
+- `delete` marks `deleted=true` with a new `jid`
+- `latest_jid` is monotonic across mixed ops
+- `find_by_path` returns the most recent record for that path
+- `records_since(jid)` returns only rows with `jid > since`, in jid order
+- `next_unsynced` / `mark_synced` flow: unsynced rows surface, marking removes them
+- Empty-DB edge cases: `latest_jid` on empty, `records_since(0)` on empty
+
+### `indexer.rs`
+
+Already has `truncate_to_seconds`. Add:
+
+- `check_index_once` on a `TempDir`:
+  - New file → `CreateForm` recorded in registry
+  - Modified file → `UpdateForm` recorded
+  - Deleted file → `DeleteForm` recorded
+  - Unchanged file → no-op
+  - Directories skipped
+  - Hidden files handled per current behavior (assert whatever the code does — pin it)
+- `run` loop: drive a real `TempDir`, push file events through the channel, assert rows land in the registry and the `local_registry_updated_tx` is pinged
+
+### `remote.rs` (against `wiremock`)
+
+- `commit` happy path: returns `ok`, new jid
+- `commit` with needed-chunks response: client surfaces the missing-hash set
+- `commit` 401 → `SyncError::Unauthorized` (or whatever current variant); 500 → generic error
+- `list(since_jid)` returns ordered records; handles empty response
+- `poll` returns when server returns 200; returns cleanly on timeout
+- `upload_chunks` forms correct multipart body; success → ok; 400 → error surfaces
+- `download_chunks` decodes multipart response into `Vec<(hash, bytes)>`
+- `check_chunks` returns the missing hash set
+- All requests carry `Authorization: Bearer <token>` header
+
+### `syncer.rs` (highest-value surface)
+
+Mock `Remote` (via `wiremock` or a hand-rolled trait impl — see Open Questions §6), real registry + real FS tempdir:
+
+- **Upload path:** unsynced local record → `commit` reports needed chunks → `upload_chunks` → second `commit` → row `mark_synced`. Asserts `jid` assigned, chunks uploaded exactly once.
+- **Download path:** `list` returns newer records → `check_chunks` identifies missing → `download_chunks` pulls them → `chunker.save` reconstructs file on disk → local registry updated to matching `jid`.
+- **Conflict:** local pending + incoming remote record for same path. Pin current behavior (document in test what wins, whether conflict resolution happens, etc.).
+- **`download_only=true`** skips the upload half entirely — assert no `commit`/`upload_chunks` calls observed by wiremock.
+- **Status listener** receives `Syncing` → `Idle` transitions at the right moments; `Error` on failure.
+- **Error propagation:** wiremock returns 500 → syncer surfaces `SyncError`, listener gets `on_complete(false, Some(msg))`.
+
+### `lib.rs`
+
+- `extract_uid_from_jwt`:
+  - Happy path: returns `uid` from a well-formed token
+  - Malformed token (wrong number of parts) currently `panic!`s — pin this, or if the design calls for returning a `Result` note it as a follow-up
+  - Missing `uid` claim: same — pin current behavior
+- `run_async` smoke test: wiremock returns empty `list`, no local files; spawn run, cancel via `CancellationToken` after a brief moment, assert it exits cleanly and listener sees `Syncing`→`Idle` (or completion callback)
+- `run_upload_once` / `run_download_once`: short integration against wiremock
+
+---
+
+## 3. Server test coverage
+
+### `auth/token.rs`
+
+- `sign` + `verify` round-trip returns the original `uid`
+- Verification rejects wrong-secret, expired token, malformed token
+- `uid` extraction correct
+
+### `auth/request.rs`
+
+Via `rocket_client()`, mounted on a simple test route that echoes `user.uid`:
+
+- Valid token → route receives correct `User { uid }`
+- Missing `Authorization` header → 401
+- Malformed bearer (no "Bearer " prefix, empty token) → 401
+- Expired / bad-signature token → 401
+
+### `auth/user.rs`, `auth/mod.rs`
+
+Covered transitively; no dedicated tests (they are trivial type re-exports).
+
+### `chunk_id.rs`
+
+Pure functions:
+
+- `chunk_path(uid, hash)` produces the expected on-disk layout (e.g., `uid/aa/bb/…`). Exact layout derived from reading the current implementation.
+- Different `(uid, hash)` pairs never collide to the same path
+- Round-trip parse (if a reverse helper exists)
+- Edge hashes: shortest legal length, all-zero, mixed case
+
+### `metadata/db.rs`
+
+Pool / migration helpers run cleanly against a fresh tempdir SQLite.
+
+### `metadata/models.rs` (extend)
+
+Already has construction tests. Add a diesel insert + select round-trip using `fresh_server_pool()` to verify the `Insertable`/`Queryable` derives match the schema.
+
+### `metadata/middleware.rs`
+
+Via `rocket_client()`, verify a representative route returns the shape middleware produces (e.g., uniform error body on a 4xx, CORS headers present if applicable).
+
+### `metadata/notification.rs`
+
+- `notify(uid)` wakes a pending `poll(uid)`
+- `poll` for a different `uid` does not wake
+- `poll` with a short timeout returns cleanly when nothing fires
+- Concurrent pollers on the same `uid` all wake on a single `notify`
+
+### `metadata/request.rs` / `response.rs`
+
+2–3 direct serde round-trip tests with edge values: empty vectors, unicode paths, very long paths. Otherwise covered transitively by route tests.
+
+### `metadata/mod.rs` (routes)
+
+Using `rocket::local::asynchronous::Client`:
+
+- `POST /metadata/commit` happy path (all chunks present) → 200 with `ok` + new `jid`
+- `POST /metadata/commit` with missing chunks → 200 with `needed_chunks` set, no `jid` advance (verify DB state)
+- `POST /metadata/commit` with invalid/missing auth → 401
+- `GET /metadata/list?since=…` returns only rows with `jid > since`, ordered, scoped to the authenticated `uid` — verify another `uid`'s rows are **not** visible
+- `GET /metadata/poll` wakes on concurrent `commit`: spawn a poller, then trigger a commit in another task; assert the poller returns a non-empty response within the timeout
+- Path validation: paths containing `..`, empty paths, and overly long paths behave per current code — pin whatever it does today
+
+### `chunks/mod.rs` (routes)
+
+- `POST /chunks/upload` multipart: valid chunks stored on disk under the uid namespace, returns ok; file contents on disk match posted bytes
+- Upload with hash mismatch (posted bytes hash ≠ claimed hash) → 400 and no file written
+- `POST /chunks/check` with a mix of existing + missing hashes → returns the missing subset
+- `GET /chunks/download?hashes=…` returns multipart with the requested chunks; 404 if any hash is missing for that uid
+- All three require auth (401 without)
+- **uid isolation:** uid=A uploads a chunk; uid=B cannot download or check-see that chunk
+
+### `chunks/request.rs` / `response.rs`
+
+Multipart parsing edge cases — empty body, malformed boundary — covered transitively by the route tests above.
+
+### `create_server()` in `lib.rs`
+
+Smoke test: builds, all expected routes mounted (hit each path once and assert not-404).
+
+---
+
+## 4. End-to-end tests (`client/tests/e2e_tests.rs`)
+
+Each test spawns `create_server()` on `127.0.0.1:0` (ephemeral port) with tempdir DB + chunk storage, reads the bound port from the Rocket instance, and drives the real client against it using the public `run_upload_once` / `run_download_once` APIs.
+
+1. **Upload → download on a second client.** Client A puts 3 files in its storage, runs `run_upload_once`; client B (fresh tempdir + fresh client DB, same uid) runs `run_download_once`; assert identical file contents.
+2. **Modify → sync.** After (1), modify a file on A; sync A; sync B; assert B sees the new content and the old version is replaced.
+3. **Delete propagates.** Delete a file on A; sync A; sync B; assert B's file is removed.
+4. **Two uids don't see each other.** uid=1 syncs a file; uid=2 calls list via a fresh client — gets nothing.
+5. **Binary round-trip.** A 2MB random-bytes file syncs A → B byte-identically.
+
+Each test tears down the spawned server in a `Drop`/explicit shutdown path.
+
+---
+
+## 5. Dependencies, execution, CI
+
+### Cargo changes
+
+- `client/Cargo.toml` dev-deps: already has `wiremock`, `tempfile`, `mockall`, `proptest`, `tokio-test`. **No additions.**
+- `server/Cargo.toml` dev-deps: add `tempfile`. Everything else is already present (`rocket` with `json`, `mockall`, `tokio-test`, `proptest`).
+- Both crates need `diesel_migrations` (client already has it; server already has it) to embed migrations into the shared test helpers.
+
+### Running
+
+- `cargo test --workspace` runs everything.
+- E2E tests live in `client/tests/e2e_tests.rs` — no `#[ignore]` by default, but named with an `e2e_` prefix so `cargo test --workspace -- --skip e2e_` skips them when iterating.
+- No new CI jobs, no coverage gate. Existing CI runs `cargo test --workspace`.
+
+### Out of scope (YAGNI)
+
+- `cargo tarpaulin` or any coverage percentage gate
+- Android / iOS FFI harness tests (covered transitively via the Rust functions they wrap)
+- Mutation testing, additional fuzz beyond existing `proptest`
+- Benchmarks / perf regression tests
+- Load / stress tests on the server
+
+---
+
+## 6. Open questions resolved during design
+
+- **Mocking `Remote` in syncer tests.** `Remote` is a concrete struct; we use `wiremock` against a `MockServer` so the real `reqwest` path runs. This avoids a trait refactor.
+- **Pinning vs. fixing existing behavior.** Where current behavior is ambiguous (hidden files, path validation, conflict resolution, `extract_uid_from_jwt` on malformed input), tests **pin current behavior** with a comment noting the behavior is being documented, not validated as correct. Fixes are out of scope for this pass.
+
+---
+
+## 7. Deliverables
+
+- ~11 new test files across both crates (see layout in §1)
+- 2 shared-helper modules (`client/tests/common/mod.rs`, `server/tests/common/mod.rs`)
+- Extensions to existing inline `#[cfg(test)]` blocks in `chunker.rs`, `indexer.rs`, `models.rs`
+- One dev-dep addition (`tempfile` in `server/Cargo.toml`)
+- No production code changes. If any are required to make a seam testable, they are called out in the implementation plan as small, local changes.


### PR DESCRIPTION
## Summary

Implements **Plan 1** of a multi-plan test-coverage effort for the `cooklang-sync-client` and `cooklang-sync-server` crates. See the design spec in `docs/superpowers/specs/2026-04-15-library-test-coverage-design.md` and Plan 1 itself in `docs/superpowers/plans/2026-04-15-test-coverage-plan-1-foundation.md`.

**Plan 1 scope:** shared test helpers plus leaf-level client module coverage. Later plans (2–6) will cover registry/indexer, remote/syncer, the server, and end-to-end tests.

## What's in this PR

- `client/tests/common/mod.rs` — shared helpers: `fresh_client_pool()`, `tempdir_with_files()`, `sample_jwt()`
- `client/tests/connection_tests.rs` — pool creation, migrations, checkout (3 tests, 1 `#[ignore]` for the slow r2d2-retry error path)
- `client/tests/context_tests.rs` — `SyncContext` listener forwarding + parent/child cancellation (6 tests)
- `client/tests/file_watcher_tests.rs` — `async_watcher` file-event smoke test (1 test)
- `client/tests/lib_jwt_tests.rs` — pins `extract_uid_from_jwt` success and panic paths (6 tests)
- `client/src/errors.rs` — appended `#[cfg(test)]` block, 4 tests for `SyncError` conversion and `Display`
- `client/src/chunker.rs` — 4 new tests inside existing `#[cfg(test)]` block: `hashify` error, `save` missing-chunk error, `delete(path)` round-trip, multi-chunk text

**Zero production code changes.** One attempted production tweak was reverted during review.

## Numbers

- 20 new tests added (65 passing in the client suite, up from 45)
- 1 ignored (slow error-path test; runs with `cargo test -- --ignored`)
- 0 new warnings in `cargo build --workspace`
- Full client suite runtime: ~2.5s (dominated by the 2s file-watcher debounce window)

## Test plan

- [x] `cargo test -p cooklang-sync-client` — all green
- [x] `cargo test --workspace` — all green
- [x] `cargo build --workspace` — no new warnings
- [x] Two-stage review per task (spec compliance + code quality) plus whole-branch final review

## Follow-up plans

Not in this PR — each will land separately:

- Plan 2: client `registry` + `indexer` integration tests
- Plan 3: client `remote` (wiremock) + `syncer` tests
- Plan 4: server unit tests (auth, `chunk_id`, metadata models/db/notification, request/response serde)
- Plan 5: server route tests (metadata, chunks, middleware, `create_server` smoke)
- Plan 6: end-to-end client ↔ server tests