### PR TITLE
Regenerate Swift bindings and commit them on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,15 @@ jobs:
           name: ios-artifacts
           path: cooklang-sync-ios.zip
 
+      # The SPM package compiles swift/Sources/CooklangSync from the repo, not
+      # from the release zip. prepare-release commits these back so the checked-in
+      # bindings can never drift from the xcframework they are generated against.
+      - name: Upload Swift bindings
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-swift-bindings
+          path: target/ios/swift/*.swift
+
     outputs:
       checksum: ${{ steps.checksum.outputs.CHECKSUM }}
 
@@ -385,6 +394,24 @@ jobs:
           )
           EOF
 
+      - name: Clear checked-in Swift bindings
+        run: rm -f swift/Sources/CooklangSync/*.swift
+
+      - name: Sync generated Swift bindings into the package sources
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-swift-bindings
+          path: swift/Sources/CooklangSync
+
+      - name: Verify bindings landed
+        run: |
+          SWIFT_COUNT=$(find swift/Sources/CooklangSync -name "*.swift" | wc -l)
+          if [ "$SWIFT_COUNT" -eq 0 ]; then
+            echo "ERROR: No Swift bindings in swift/Sources/CooklangSync!"
+            exit 1
+          fi
+          git status --short swift/Sources/CooklangSync
+
       - name: Commit Package.swift and create tag
         run: |
           VERSION="v${{ inputs.version }}"
@@ -392,8 +419,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add Package.swift
-          git commit -m "Update Package.swift for ${VERSION}" || echo "No changes to commit"
+          git add Package.swift swift/Sources/CooklangSync
+          git commit -m "Update Package.swift and Swift bindings for ${VERSION}" || echo "No changes to commit"
           git push origin main
 
           # Create tag at current commit (which includes updated Package.swift)

--- a/swift/Sources/CooklangSync/CooklangSync.swift
+++ b/swift/Sources/CooklangSync/CooklangSync.swift
@@ -900,13 +900,13 @@ public enum SyncError: Swift.Error, Equatable, Hashable, Foundation.LocalizedErr
     
     case ReqwestError(message: String)
     
-    case ReqwestWirhMiddlewareError(message: String)
-    
     case ChannelSendError(message: String)
     
     case ConnectionInitError(message: String)
     
     case Unauthorized(message: String)
+    
+    case PaymentRequired(message: String)
     
     case BodyExtractError(message: String)
     
@@ -977,19 +977,19 @@ public struct FfiConverterTypeSyncError: FfiConverterRustBuffer {
             message: try FfiConverterString.read(from: &buf)
         )
         
-        case 9: return .ReqwestWirhMiddlewareError(
+        case 9: return .ChannelSendError(
             message: try FfiConverterString.read(from: &buf)
         )
         
-        case 10: return .ChannelSendError(
+        case 10: return .ConnectionInitError(
             message: try FfiConverterString.read(from: &buf)
         )
         
-        case 11: return .ConnectionInitError(
+        case 11: return .Unauthorized(
             message: try FfiConverterString.read(from: &buf)
         )
         
-        case 12: return .Unauthorized(
+        case 12: return .PaymentRequired(
             message: try FfiConverterString.read(from: &buf)
         )
         
@@ -1040,13 +1040,13 @@ public struct FfiConverterTypeSyncError: FfiConverterRustBuffer {
             writeInt(&buf, Int32(7))
         case .ReqwestError(_ /* message is ignored*/):
             writeInt(&buf, Int32(8))
-        case .ReqwestWirhMiddlewareError(_ /* message is ignored*/):
-            writeInt(&buf, Int32(9))
         case .ChannelSendError(_ /* message is ignored*/):
-            writeInt(&buf, Int32(10))
+            writeInt(&buf, Int32(9))
         case .ConnectionInitError(_ /* message is ignored*/):
-            writeInt(&buf, Int32(11))
+            writeInt(&buf, Int32(10))
         case .Unauthorized(_ /* message is ignored*/):
+            writeInt(&buf, Int32(11))
+        case .PaymentRequired(_ /* message is ignored*/):
             writeInt(&buf, Int32(12))
         case .BodyExtractError(_ /* message is ignored*/):
             writeInt(&buf, Int32(13))


### PR DESCRIPTION
The SPM package compiles `swift/Sources/CooklangSync` straight out of the
repo, but the release workflow only ever generated the bindings into the
release zip and committed `Package.swift`. The checked-in bindings had not
been regenerated since v0.4.10, so every consumer since v0.4.11 has been
compiling an enum that no longer matches the xcframework it links against.

`SyncError` is a `flat_error`, so the variant is carried across FFI as a
positional index. The stale file still declares `ReqwestWirhMiddlewareError`
at index 9 — a variant Rust dropped in 04a0560 — which shifts everything
after it by one:

    Rust ChannelSendError    (9)  -> Swift ReqwestWirhMiddlewareError
    Rust ConnectionInitError (10) -> Swift ChannelSendError
    Rust Unauthorized        (11) -> Swift ConnectionInitError
    Rust PaymentRequired     (12) -> Swift Unauthorized

On 0.6.0 that last row is the damaging one: the 402 added in f0a517f
surfaces to iOS as `Unauthorized`, i.e. "your session expired", which is
exactly the wrong route for a product gate.

Two changes:

- Replace the stale bindings with the ones the v0.6.0 release actually
  generated (byte-identical to `cooklang-sync-ios.zip`). The only
  difference from the checked-in file is the `SyncError` enum; renamed to
  `CooklangSync.swift` to match the generator's output filename so CI can
  overwrite it in place.
- Have `prepare-release` pull the generated bindings from `build-ios` and
  commit them alongside `Package.swift`, so the tag can never again point
  at bindings that disagree with its xcframework.